### PR TITLE
Delete unused products when clearing OpenFoodFacts cache

### DIFF
--- a/app/src/commonMain/kotlin/com/maksimowiczm/foodyou/feature/diary/data/OpenFoodFactsSettingsRepository.kt
+++ b/app/src/commonMain/kotlin/com/maksimowiczm/foodyou/feature/diary/data/OpenFoodFactsSettingsRepository.kt
@@ -2,6 +2,7 @@ package com.maksimowiczm.foodyou.feature.diary.data
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import com.maksimowiczm.foodyou.feature.diary.data.model.ProductSource
 import com.maksimowiczm.foodyou.feature.diary.data.preferences.OpenFoodFactsPreferences
 import com.maksimowiczm.foodyou.feature.diary.database.dao.OpenFoodFactsDao
 import com.maksimowiczm.foodyou.feature.system.data.SystemInfoRepository
@@ -67,5 +68,6 @@ class OpenFoodFactsSettingsRepository(
 
     suspend fun clearCache() {
         openFoodFactsDao.clearPagingKeys()
+        openFoodFactsDao.deleteUnusedProducts(ProductSource.OpenFoodFacts)
     }
 }

--- a/app/src/commonMain/kotlin/com/maksimowiczm/foodyou/feature/diary/database/dao/OpenFoodFactsDao.kt
+++ b/app/src/commonMain/kotlin/com/maksimowiczm/foodyou/feature/diary/database/dao/OpenFoodFactsDao.kt
@@ -3,6 +3,7 @@ package com.maksimowiczm.foodyou.feature.diary.database.dao
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
+import com.maksimowiczm.foodyou.feature.diary.data.model.ProductSource
 import com.maksimowiczm.foodyou.feature.diary.database.entity.OpenFoodFactsPagingKey
 
 @Dao
@@ -26,4 +27,15 @@ interface OpenFoodFactsDao {
         """
     )
     suspend fun clearPagingKeys()
+
+    @Query(
+        """
+        DELETE FROM ProductEntity WHERE id IN (
+            SELECT product.id FROM ProductEntity AS product
+            LEFT JOIN WeightMeasurementEntity AS meal ON meal.productId = product.id 
+            WHERE meal.productId IS NULL AND product.productSource = :source
+        )
+        """
+    )
+    suspend fun deleteUnusedProducts(source: ProductSource)
 }


### PR DESCRIPTION
Not sure if it was intentionally not actually deleting the products, but I have too many products to scroll through :)